### PR TITLE
Allow to pass custom additional headers to requests made to Voucherify API

### DIFF
--- a/.changeset/mighty-ladybugs-enjoy.md
+++ b/.changeset/mighty-ladybugs-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': minor
+---
+
+Allow to pass additional headers to requests made to Voucherify API. Custom headers can be passed via 'customHeaders' option available in VoucherifyServerSideOptions and VoucherifyClientSideOptions. Such option might prove to be useful when debugging

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -126,6 +126,7 @@ const client = VoucherifyServerSide({
 	apiUrl: 'https://<region>.api.voucherify.io', // optional
 	apiVersion: 'v2018-08-01', // optional
 	channel: 'e-commerce', // optional
+  customHeaders: { "MY_CUSTOM_HEADER": "my_value" } // optional
 })
 ```
 
@@ -1110,6 +1111,7 @@ const client = VoucherifyClientSide({
 	clientSecretKey: 'YOUR-CLIENT-SECRET-KEY',
 	apiUrl: 'https://<region>.api.voucherify.io', // optional
 	origin: 'example.com', // read more below
+  customHeaders: { "MY_CUSTOM_HEADER": "my_value" } // optional
 })
 ```
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -126,7 +126,7 @@ const client = VoucherifyServerSide({
 	apiUrl: 'https://<region>.api.voucherify.io', // optional
 	apiVersion: 'v2018-08-01', // optional
 	channel: 'e-commerce', // optional
-  customHeaders: { "MY_CUSTOM_HEADER": "my_value" } // optional
+	customHeaders: { "MY_CUSTOM_HEADER": "my_value" } // optional
 })
 ```
 
@@ -1111,7 +1111,7 @@ const client = VoucherifyClientSide({
 	clientSecretKey: 'YOUR-CLIENT-SECRET-KEY',
 	apiUrl: 'https://<region>.api.voucherify.io', // optional
 	origin: 'example.com', // read more below
-  customHeaders: { "MY_CUSTOM_HEADER": "my_value" } // optional
+	customHeaders: { "MY_CUSTOM_HEADER": "my_value" } // optional
 })
 ```
 

--- a/packages/sdk/src/VoucherifyClientSide.ts
+++ b/packages/sdk/src/VoucherifyClientSide.ts
@@ -67,8 +67,8 @@ export interface VoucherifyClientSideOptions {
 	 * It can prove to be useful when debugging various scenarios.
 	 * ```javascript
 	 * const voucherify = VoucherifyServerSide({
-	 *		applicationId: 'YOUR-APPLICATION-ID',
-	 *		secretKey: 'YOUR-SECRET-KEY',
+	 *		clientApplicationId: 'YOUR-CLIENT-APPLICATION-ID',
+	 *		clientSecretKey: 'YOUR-CLIENT-SECRET-KEY',
 	 *		customHeaders: {
 	 *			"DEBUG-HEADER": "my_value",
 	 *			"TEST-HEADER": "another_value"

--- a/packages/sdk/src/VoucherifyClientSide.ts
+++ b/packages/sdk/src/VoucherifyClientSide.ts
@@ -62,6 +62,21 @@ export interface VoucherifyClientSideOptions {
 	 * @note in the browser, this option will be ignored. The `origin` header is a [forbidden header name](https://developer.mozilla.org/en-US/docs/Glossary/Forbidden_header_name) and it'll be automatically set by the browser for every request.
 	 */
 	origin?: string
+	/**
+	 * You can pass additional headers to requests made by the API Client.
+	 * It can prove to be useful when debugging various scenarios.
+	 * ```javascript
+	 * const voucherify = VoucherifyServerSide({
+	 *		applicationId: 'YOUR-APPLICATION-ID',
+	 *		secretKey: 'YOUR-SECRET-KEY',
+	 *		customHeaders: {
+	 *			"DEBUG-HEADER": "my_value",
+	 *			"TEST-HEADER": "another_value"
+	 *		}
+	 * })
+	 * ```
+	 */
+	customHeaders?: Record<string, string>
 }
 interface VoucherifyCustomerHeaders {
 	'X-Client-Application-Id': string
@@ -76,7 +91,7 @@ export function VoucherifyClientSide(options: VoucherifyClientSideOptions): Clie
 	assert(isOptionalString(options.apiUrl), 'VoucherifyCustomer: expected "options.baseUrl" to be a string')
 	assert(isOptionalString(options.trackingId), 'VoucherifyCustomer: expected "options.trackingId" to be a string')
 
-	const headers: VoucherifyCustomerHeaders = {
+	let headers: VoucherifyCustomerHeaders = {
 		'X-Client-Application-Id': options.clientApplicationId,
 		'X-Client-Token': options.clientSecretKey,
 		'X-Voucherify-Channel': `${environment()}-ClientSide-SDK-v${__VERSION__}`,
@@ -85,6 +100,10 @@ export function VoucherifyClientSide(options: VoucherifyClientSideOptions): Clie
 	if (environment().startsWith('Node')) {
 		assert(isString(options.origin), 'VoucherifyCustomer: "options.origin" is required in Node.js')
 		headers['origin'] = options.origin
+	}
+
+	if (isObject(options.customHeaders)) {
+		headers = Object.assign({}, headers, options.customHeaders)
 	}
 
 	const client = new RequestController({

--- a/packages/sdk/src/VoucherifyServerSide.ts
+++ b/packages/sdk/src/VoucherifyServerSide.ts
@@ -81,6 +81,21 @@ export interface VoucherifyServerSideOptions {
 	 * ```
 	 */
 	dangerouslySetSecretKeyInBrowser?: boolean
+	/**
+	 * You can pass additional headers to requests made by the API Client.
+	 * It can prove to be useful when debugging various scenarios.
+	 * ```javascript
+	 * const voucherify = VoucherifyServerSide({
+	 *		applicationId: 'YOUR-APPLICATION-ID',
+	 *		secretKey: 'YOUR-SECRET-KEY',
+	 *		customHeaders: {
+	 *			"DEBUG-HEADER": "my_value",
+	 *			"TEST-HEADER": "another_value"
+	 *		}
+	 * })
+	 * ```
+	 */
+	customHeaders?: Record<string, string>
 }
 interface VoucherifyServerSideHeaders {
 	'X-App-Id': string
@@ -113,7 +128,7 @@ export function VoucherifyServerSide(options: VoucherifyServerSideOptions) {
 	assert(isOptionalString(options.apiVersion), 'VoucherifyServerSide: expected "options.apiVersion" to be a string')
 	assert(isOptionalString(options.channel), 'VoucherifyServerSide: expected "options.channel" to be a string')
 
-	const headers: VoucherifyServerSideHeaders = {
+	let headers: VoucherifyServerSideHeaders = {
 		'X-App-Id': options.applicationId,
 		'X-App-Token': options.secretKey,
 		'X-Voucherify-Channel': options.channel || `${environment()}-SDK-v${__VERSION__}`,
@@ -121,6 +136,10 @@ export function VoucherifyServerSide(options: VoucherifyServerSideOptions) {
 	}
 	if (options.apiVersion) {
 		headers['X-Voucherify-API-Version'] = options.apiVersion
+	}
+
+	if (isObject(options.customHeaders)) {
+		headers = Object.assign({}, headers, options.customHeaders)
 	}
 
 	/**


### PR DESCRIPTION
# Changes:  
Adding new option: `customHeaders` allowing developer to pass additional headers that should be send to Voucherify API with each request. This might prove to be useful when debugging different technical cases