### PR TITLE
[Improvement + BugFix] - Stringify query params passed to POST requests + allow to pass query params for promotion validation

### DIFF
--- a/.changeset/eleven-vans-swim.md
+++ b/.changeset/eleven-vans-swim.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Query params passed to `this.client.post` method are now correctly stringified. Added possibility to pass query params to `voucherify.promotions.validate` method in order to allow developers using SDK to pass advanced filters to restrict possible range of promotion campaigns against which validation should be performed.

--- a/packages/sdk/src/Promotions.ts
+++ b/packages/sdk/src/Promotions.ts
@@ -14,7 +14,7 @@ export class Promotions {
 	/**
 	 * @see https://docs.voucherify.io/reference/validate-promotions-1
 	 */
-	public validate(params: T.PromotionsValidateParams) {
-		return this.client.post<T.PromotionsValidateResponse>('/promotions/validation', params)
+	public validate(body: T.PromotionsValidateParams, params?: T.PromotionsValidateQueryParams) {
+		return this.client.post<T.PromotionsValidateResponse>('/promotions/validation', body, params)
 	}
 }

--- a/packages/sdk/src/RequestController.ts
+++ b/packages/sdk/src/RequestController.ts
@@ -58,7 +58,13 @@ export class RequestController {
 		params?: Record<string, any>,
 		headers?: Record<string, any>,
 	): Promise<T> {
-		const response = await this.request.post<T>(path, body, { params, headers })
+		const response = await this.request.post<T>(path, body, {
+			params,
+			paramsSerializer: function (params) {
+				return Qs.stringify(params)
+			},
+			headers,
+		})
 		return response.data
 	}
 	public async put<T>(path: string, body: Record<string, any>, params?: Record<string, any>): Promise<T> {

--- a/packages/sdk/src/types/Promotions.ts
+++ b/packages/sdk/src/types/Promotions.ts
@@ -72,6 +72,11 @@ export interface PromotionsValidateParams {
 	metadata?: Record<string, any>
 }
 
+export interface PromotionsValidateQueryParams {
+	audienceRulesOnly?: boolean
+	filters?: Record<string, any>
+}
+
 export interface PromotionsValidateResponse {
 	valid: boolean
 	promotions?: {


### PR DESCRIPTION
# What:  
This Pull requests fixes following issues:
- `query params` passed to `this.client.post` method making POST request to Voucherify API were not stringified correctly
- `voucherify.promotions.validation` method was not accepting `query params` making it impossible to use advanced filters to restrict range of promotion campaigns against which validation should be performed - issue ref: https://github.com/voucherifyio/voucherify-js-sdk/issues/111