### PR TITLE
[Improvement] Support for v1/customers/{customer_ID}/activities endpoint

### DIFF
--- a/.changeset/sour-weeks-explode.md
+++ b/.changeset/sour-weeks-explode.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Added support for listing customer activities by customerId. Additionally user can pass query params allowing for better filtering. API Reference: https://docs.voucherify.io/reference/get-customer-activities

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -514,6 +514,7 @@ Methods are provided within `client.customers.*` namespace.
 - [Delete Customer](#delete-customer)
 - [List Customers](#list-customers)
 - [Update Customer's Consents](#update-customers-consents)
+- [List Customer's Activities](#list-customers-activities)
 
 #### [Create Customer](https://docs.voucherify.io/reference/create-customer)
 
@@ -586,6 +587,13 @@ Keep in mind this operation may drain your API call limits fairly quickly - each
 
 ```javascript
 client.customers.updateConsents(customer, consents)
+```
+
+#### [List Customers Activities](https://docs.voucherify.io/reference/get-customer-activities)
+
+```javascript
+client.customers.listActivities(customerId)
+client.customers.listActivities(customerId, params)
 ```
 
 ---

--- a/packages/sdk/src/Customers.ts
+++ b/packages/sdk/src/Customers.ts
@@ -85,6 +85,13 @@ class Customers {
 	public updateConsents(idOrSourceId: string, consents: T.CustomersUpdateConsentsBody) {
 		return this.client.put<undefined>(`/customers/${encode(idOrSourceId)}/consents`, consents)
 	}
+
+	/**
+	 * @see https://docs.voucherify.io/reference/get-customer-activities
+	 */
+	public listActivities(customerId: string, params?: T.CustomerActivitiesListQueryParams) {
+		return this.client.get<T.CustomerActivitiesListResponse>(`/customers/${encode(customerId)}/activities`, params)
+	}
 }
 
 export { Customers }

--- a/packages/sdk/src/types/Customers.ts
+++ b/packages/sdk/src/types/Customers.ts
@@ -102,6 +102,22 @@ export interface CustomersCommonListResponse {
 	has_more?: boolean
 }
 
+export interface CustomerActivitiesListQueryParams {
+	limit?: number
+	order?: 'created_at' | '-created_at'
+	starting_after?: string
+	starting_after_id?: string
+	campaign_type?: 'LOYALTY_PROGRAM' | 'PROMOTION' | 'DISCOUNT_COUPONS' | 'GIFT_VOUCHERS' | 'REFERRAL_PROGRAM'
+	campaign_id?: string
+}
+
+export interface CustomerActivitiesListResponse {
+	object: 'list'
+	total: number
+	data_ref: 'data'
+	data: Record<string, any>[]
+}
+
 export type CustomersCreateBody = CustomerRequest
 export type CustomersCreateResponse = CustomerObject | CustomerUnconfirmed
 


### PR DESCRIPTION
# What:  
Add support for calling: `v1/customers/{customer_ID}/activities` endpoint - https://docs.voucherify.io/reference/get-customer-activities

Closes https://github.com/voucherifyio/voucherify-js-sdk/issues/116