### PR TITLE
Add missing discount amounts on order type for validate voucher response

### DIFF
--- a/.changeset/bright-humans-type.md
+++ b/.changeset/bright-humans-type.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Adding missing discount amounts on order for validate voucher type response

--- a/packages/sdk/src/types/Validations.ts
+++ b/packages/sdk/src/types/Validations.ts
@@ -53,6 +53,8 @@ export interface ValidationsValidateVoucherResponse {
 		discount_amount: number
 		total_discount_amount: number
 		total_amount: number
+		applied_discount_amount: number
+		total_applied_discount_amount: number
 		items?: OrdersItem[]
 	}
 	start_date?: string

--- a/packages/sdk/src/types/Validations.ts
+++ b/packages/sdk/src/types/Validations.ts
@@ -53,8 +53,8 @@ export interface ValidationsValidateVoucherResponse {
 		discount_amount: number
 		total_discount_amount: number
 		total_amount: number
-		applied_discount_amount: number
-		total_applied_discount_amount: number
+		applied_discount_amount?: number
+		total_applied_discount_amount?: number
 		items?: OrdersItem[]
 	}
 	start_date?: string


### PR DESCRIPTION
Missing `items_applied_discount_amount` and `total_applied_discount_amount`