### PR TITLE
[patch] Add missing documentation links for MetadataSchemas API methods

### DIFF
--- a/.changeset/five-hotels-applaud.md
+++ b/.changeset/five-hotels-applaud.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Added documentation links to MetadataSchemas API methods

--- a/packages/sdk/src/MetadataSchemas.ts
+++ b/packages/sdk/src/MetadataSchemas.ts
@@ -6,10 +6,16 @@ import type { RequestController } from './RequestController'
 export class MetadataSchemas {
 	constructor(private client: RequestController) {}
 
+	/**
+	 * @see https://docs.voucherify.io/reference/list-metadata-schemas
+	 */
 	public list() {
 		return this.client.get<T.MetadataSchemasListResponse>('/metadata-schemas')
 	}
 
+	/**
+	 * @see https://docs.voucherify.io/reference/get-metadata-schema
+	 */
 	public get(schemaName: string) {
 		return this.client.get<T.MetadataSchemasGetResponse>(`/metadata-schemas/${encode(schemaName)}`)
 	}


### PR DESCRIPTION
# What:  
Add missing documentation links for:
- `MetaedaSchemas.list` method
- `MetadataSchemas.get` method