### PR TITLE
[patch] Make customer's ID field optional when calling redeem method

### DIFF
--- a/.changeset/selfish-pears-wink.md
+++ b/.changeset/selfish-pears-wink.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Override SimpleCustomer type to make 'id' property not required in 'RedemptionsRedeemBody' interface since passing ID of customer when redeeming is not required by design

--- a/packages/sdk/src/types/Redemptions.ts
+++ b/packages/sdk/src/types/Redemptions.ts
@@ -8,7 +8,7 @@ import { StackableOptions, StackableRedeemableParams } from './Stackable'
 
 export interface RedemptionsRedeemBody {
 	tracking_id?: string
-	customer?: SimpleCustomer & { description?: string }
+	customer?: Omit<SimpleCustomer, 'id'> & { description?: string; id?: string }
 	order?: Pick<Partial<OrdersCreateResponse>, 'id' | 'source_id' | 'amount' | 'items' | 'status' | 'metadata'>
 	metadata?: Record<string, any>
 	reward?: RewardRedemptionParams


### PR DESCRIPTION
# Why:  
https://github.com/voucherifyio/voucherify-js-sdk/issues/140