### PR TITLE
[patch] Add missing 'name', 'start_date' and 'expiration_date' properties to PromotionsValidateResponse

### DIFF
--- a/.changeset/tricky-rings-cry.md
+++ b/.changeset/tricky-rings-cry.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Add missing 'name', 'start_date' and 'expiration_date' properties to PromotionsValidateResponse interface

--- a/packages/sdk/src/types/Promotions.ts
+++ b/packages/sdk/src/types/Promotions.ts
@@ -83,6 +83,9 @@ export interface PromotionsValidateResponse {
 		id: string
 		object: 'promotion_tier'
 		banner?: string
+		name: string
+		start_date?: string
+		expiration_date?: string
 		discount?: DiscountUnit | DiscountAmount | DiscountPercent
 		discount_amount?: number
 		metadata?: Record<string, any>


### PR DESCRIPTION
# Why:
https://github.com/voucherifyio/voucherify-js-sdk/issues/143