### PR TITLE
[patch] Fixes to request and response payload of promotions validation endpoint

### DIFF
--- a/.changeset/chilled-buckets-flow.md
+++ b/.changeset/chilled-buckets-flow.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Drop not required customer id property when running promotion validation. Add missing proeprties to promotion validation response

--- a/packages/sdk/src/types/DiscountVoucher.ts
+++ b/packages/sdk/src/types/DiscountVoucher.ts
@@ -28,11 +28,25 @@ export type DiscountPercentVouchersEffectTypes = 'APPLY_TO_ORDER' | 'APPLY_TO_IT
 
 export type DiscountFixedVouchersEffectTypes = 'APPLY_TO_ORDER' | 'APPLY_TO_ITEMS'
 
+interface SimpleSkuDiscountUnit {
+	id: string
+	source_id?: string
+	sku: string
+}
+
+interface SimpleProductDiscountUnit {
+	id: string
+	source_id?: string
+	name: string
+}
+
 export interface DiscountUnit {
 	type?: DiscountVouchersTypesEnum.UNIT
 	unit_off?: number
 	effect?: DiscountUnitVouchersEffectTypes
 	unit_type?: string
+	product?: SimpleProductDiscountUnit
+	sku?: SimpleSkuDiscountUnit
 }
 
 export interface DiscountAmount {

--- a/packages/sdk/src/types/Promotions.ts
+++ b/packages/sdk/src/types/Promotions.ts
@@ -88,6 +88,7 @@ export interface PromotionsValidateResponse {
 		expiration_date?: string
 		discount?: DiscountUnit | DiscountAmount | DiscountPercent
 		discount_amount?: number
+		applied_discount_amount?: number
 		metadata?: Record<string, any>
 		order?: {
 			id?: string
@@ -95,7 +96,13 @@ export interface PromotionsValidateResponse {
 			amount: number
 			items?: OrdersItem[]
 			metadata?: Record<string, any>
+			discount_amount?: number
+			total_discount_amount?: number
+			total_amount?: number
+			applied_discount_amount?: number
+			total_applied_discount_amount?: number
 		}
+		hierarchy?: number
 	}[]
 	tracking_id?: string
 }

--- a/packages/sdk/src/types/Promotions.ts
+++ b/packages/sdk/src/types/Promotions.ts
@@ -94,6 +94,9 @@ export interface PromotionsValidateResponse {
 			id?: string
 			source_id?: string
 			amount: number
+			initial_amount?: number
+			items_discount_amount?: number
+			items_applied_discount_amount?: number
 			items?: OrdersItem[]
 			metadata?: Record<string, any>
 			discount_amount?: number

--- a/packages/sdk/src/types/Promotions.ts
+++ b/packages/sdk/src/types/Promotions.ts
@@ -61,7 +61,7 @@ export interface PromotionsCreate {
 }
 
 export interface PromotionsValidateParams {
-	customer?: Omit<SimpleCustomer, 'object'> & { description?: string }
+	customer?: Omit<SimpleCustomer, 'id' | 'object'> & { description?: string; id?: string }
 	order?: {
 		id?: string
 		source_id?: string

--- a/packages/sdk/src/types/Validations.ts
+++ b/packages/sdk/src/types/Validations.ts
@@ -56,6 +56,9 @@ export interface ValidationsValidateVoucherResponse {
 		applied_discount_amount?: number
 		total_applied_discount_amount?: number
 		items?: OrdersItem[]
+		initial_amount?: number
+		items_discount_amount?: number
+		items_applied_discount_amount?: number
 	}
 	start_date?: string
 	expiration_date?: string


### PR DESCRIPTION
# Why:
Issues:
https://github.com/voucherifyio/voucherify-js-sdk/issues/146
https://github.com/voucherifyio/voucherify-js-sdk/issues/147
https://github.com/voucherifyio/voucherify-js-sdk/issues/148

# What:  
- Drop `id` from `customer` in `promotions/validation` endpoint
- Add `applied_discount_amount` to `PromotionsValidateResponse` root type
- Add `hierarchy` to `PromotionsValidateResponse` root type
- Add `initial_amount` to `PromotionsValidateResponse` nested order type
- Add `items_discount_amount` to `PromotionsValidateResponse` nested order type
- Add `items_applied_discount_amount` to `PromotionsValidateResponse` nested order type
- Add `discount_amount` to `PromotionsValidateResponse` nested order type
- Add `total_discount_amount` to `PromotionsValidateResponse` nested order type
- Add `total_amount` to `PromotionsValidateResponse` nested order type
- Add `applied_discount_amount` to `PromotionsValidateResponse` nested order type
- Add `total_applied_discount_amount` to `PromotionsValidateResponse` nested order type
- Add `product` to `DiscountUnit` type
- Add `sku` to `DiscountUnit` type
- Add `initial_amount` to `ValidationsValidateVoucherResponse` type
- Add `items_discount_amount` to `ValidationsValidateVoucherResponse` type
- Add `items_applied_discount_amount` to `ValidationsValidateVoucherResponse` type