### PR TITLE
[patch] Add missing properties to OrdersItem interface

### DIFF
--- a/.changeset/curly-balloons-impress.md
+++ b/.changeset/curly-balloons-impress.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Added missing properties to OrdersItem interface

--- a/packages/sdk/src/types/Orders.ts
+++ b/packages/sdk/src/types/Orders.ts
@@ -5,20 +5,32 @@ export interface OrdersItem {
 	product_id?: string
 	related_object?: 'product' | 'sku'
 	source_id?: string
+	discount_quantity?: number
+	initial_quantity?: number
 	quantity?: number
 	price?: number
 	amount?: number
 	discount_amount?: number
+	initial_amount?: number
 	applied_discount_amount?: number
+	subtotal_amount?: number
 	product?: {
+		id?: string
+		source_id?: string
 		override?: boolean
 		name?: string
 		metadata?: Record<string, any>
+		price?: number
 	}
 	sku?: {
+		id?: string
+		source_id?: string
 		override?: boolean
 		sku?: string
+		price?: number
 	}
+	object?: 'order_item'
+	metadata?: Record<string, any>
 }
 
 export interface OrdersCreate {


### PR DESCRIPTION
# Related issues:
https://github.com/voucherifyio/voucherify-js-sdk/issues/151

# Change type:
**PATCH**

# Changes:  
- Add `discount_quantity` property to `OrdersItem` interface
- Add `initial_quantity` property to `OrdersItem` interface
- Add `initial_amount` property to `OrdersItem` interface
- Add `subtotal_amount` property to `OrdersItem` interface
- Add `object` property to `OrdersItem` interface
- Add `metadata` property to `OrdersItem` interface
- Add `product.id` property to `OrdersItem` interface
- Add `product.source_id` property to `OrdersItem` interface
- Add `product.price` property to `OrdersItem` interface
- Add `sku.id` property to `OrdersItem` interface
- Add `sku.source_id` property to `OrdersItem` interface
- Add `sku.price` property to `OrdersItem` interface