### PR TITLE
[patch] Add missing property to OrdersCreateResponse interface

### DIFF
--- a/.changeset/brown-birds-fly.md
+++ b/.changeset/brown-birds-fly.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Add missing property to OrdersCreateResponse interface

--- a/packages/sdk/src/types/Orders.ts
+++ b/packages/sdk/src/types/Orders.ts
@@ -56,6 +56,7 @@ export interface OrdersCreateResponse {
 	total_discount_amount?: number
 	applied_discount_amount?: number
 	items_applied_discount_amount?: number
+	total_amount?: number
 	total_applied_discount_amount?: number
 	items?: OrdersItem[]
 	metadata?: Record<string, any>


### PR DESCRIPTION

# Change type:

**PATCH**

# Changes

- Add missing `total_amount` property to `OrdersCreateResponse` interface
