### PR TITLE
[patch] Add missing property to `VouchersResponse` interface

### DIFF
--- a/.changeset/tidy-apricots-allow.md
+++ b/.changeset/tidy-apricots-allow.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+add missing created_at property to VouchersResponse, LoyaltiesRedeemRewardResponse, CampaignsAddVoucherResponse, and ClientSideVoucherListing interfaces

--- a/packages/sdk/src/types/Campaigns.ts
+++ b/packages/sdk/src/types/Campaigns.ts
@@ -130,6 +130,7 @@ export type CampaignsAddVoucherResponse = Pick<
 	| 'object'
 	| 'campaign'
 	| 'category'
+	| 'created_at'
 	| 'type'
 	| 'discount'
 	| 'gift'

--- a/packages/sdk/src/types/ClientSide.ts
+++ b/packages/sdk/src/types/ClientSide.ts
@@ -42,7 +42,7 @@ export interface ClientSideValidateParams {
 export type ClientSideListVouchersParams = VouchersListParams
 export type ClientSideVoucherListing = Pick<
 	VouchersResponse,
-	'active' | 'code' | 'metadata' | 'assets' | 'object' | 'expiration_date' | 'start_date'
+	'active' | 'code' | 'metadata' | 'assets' | 'object' | 'expiration_date' | 'start_date' | 'created_at'
 >
 
 export interface ClientSideListVouchersResponse {

--- a/packages/sdk/src/types/Loyalties.ts
+++ b/packages/sdk/src/types/Loyalties.ts
@@ -468,6 +468,7 @@ export interface LoyaltiesRedeemRewardResponse {
 		is_referral_code: boolean
 		referrer_id: string
 		holder_id: string
+		created_at: string
 		updated_at: string
 		holder: {
 			id: string

--- a/packages/sdk/src/types/Vouchers.ts
+++ b/packages/sdk/src/types/Vouchers.ts
@@ -77,6 +77,7 @@ export interface VouchersResponse {
 	referrer_id?: string
 	holder_id?: string
 	updated_at?: string
+	created_at: string
 	object: 'voucher'
 	validation_rules_assignments: {
 		object: 'list'


### PR DESCRIPTION
# Change type:

**PATCH**

# Changes

- Add missing `created_at` property to `VouchersResponse`, `LoyaltiesRedeemRewardResponse`, `CampaignsAddVoucherResponse`, and `ClientSideVoucherListing` interfaces.
