### PR TITLE
Fix typing of RedemptionsRedeemStackableResponse

### DIFF
--- a/packages/sdk/src/types/Redemptions.ts
+++ b/packages/sdk/src/types/Redemptions.ts
@@ -183,7 +183,7 @@ export type RedemptionsRedeemStackableOrderResponse = OrdersCreateResponse & {
 
 export interface RedemptionsRedeemStackableResponse {
 	redemptions: RedemptionsRedeemStackableRedemptionResult[]
-	parent_redemption: {
+	parent_redemption?: {
 		id: string
 		object: 'redemption'
 		date: string


### PR DESCRIPTION
Currently `parent_redemption` field is marked as required in the `RedemptionsRedeemStackableResponse` but in reality this field is not returned in case there is only single voucher being redeemed. See below screenshot:

![Screenshot 2022-10-17 at 17 05 47](https://user-images.githubusercontent.com/3482956/196217669-770ca8d4-3dcd-4716-a74e-487eb7543267.png)
