### PR TITLE
[patch] Bumping axios to 0.21.4

### DIFF
--- a/.changeset/cool-boxes-wait.md
+++ b/.changeset/cool-boxes-wait.md
@@ -1,0 +1,6 @@
+---
+'@voucherify/sdk': patch
+'@voucherify/react-widget': patch
+---
+
+Update axios to 0.21.4 in SDK package

--- a/package.json
+++ b/package.json
@@ -63,7 +63,5 @@
 		"**/ts-jest": "26.4.4",
 		"**/typescript": "4.1.3"
 	},
-	"dependencies": {
-		"axios": "0.21.4"
-	}
+	"dependencies": {}
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -36,7 +36,7 @@
 		"prepublish": "yarn build"
 	},
 	"dependencies": {
-		"axios": "0.21.2",
+		"axios": "0.21.4",
 		"qs": "6.9.6"
 	},
 	"devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3152,13 +3152,6 @@ axios@0.21.2:
   dependencies:
     follow-redirects "^1.14.0"
 
-axios@0.21.4:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
-  dependencies:
-    follow-redirects "^1.14.0"
-
 axios@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.2.0.tgz#1cb65bd75162c70e9f8d118a905126c4a201d383"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3145,10 +3145,10 @@ axe-core@^4.0.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.2.1.tgz#2e50bcf10ee5b819014f6e342e41e45096239e34"
   integrity sha512-evY7DN8qSIbsW2H/TWQ1bX3sXN1d4MNb5Vb4n7BzPuCwRHdkZ1H2eNLuSh73EoQqkGKUtju2G2HCcjCfhvZIAA==
 
-axios@0.21.2:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.2.tgz#21297d5084b2aeeb422f5d38e7be4fbb82239017"
-  integrity sha512-87otirqUw3e8CzHTMO+/9kh/FSgXt/eVDvipijwDtEuwbkySWZ9SBm6VEubmJ/kLKEoLQV/POhxXFb66bfekfg==
+axios@0.21.4:
+  version "0.21.4"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
+  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
 


### PR DESCRIPTION
# Type: patch

# What:  
- Bumping `axios`, previous PR: https://github.com/voucherifyio/voucherify-js-sdk/pull/165 added new dependency to axios in root package.json instead of bumping `axios` in `packages/sdk`