### PR TITLE
[patch] Bumping qs to 6.9.7 version to fix CVE-2022-24999 / GHSA-hrpp-h998-j3pp

### DIFF
--- a/.changeset/famous-donkeys-notice.md
+++ b/.changeset/famous-donkeys-notice.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Bump qs dependency to 6.9.7 version to fix CVE-2022-24999 / GHSA-hrpp-h998-j3pp

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -37,10 +37,10 @@
 	},
 	"dependencies": {
 		"axios": "0.21.4",
-		"qs": "6.9.6"
+		"qs": "6.9.7"
 	},
 	"devDependencies": {
-		"@types/qs": "6.9.6"
+		"@types/qs": "6.9.7"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2655,10 +2655,10 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
-"@types/qs@6.9.6":
-  version "6.9.6"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.6.tgz#df9c3c8b31a247ec315e6996566be3171df4b3b1"
-  integrity sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==
+"@types/qs@6.9.7":
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
+  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
 
 "@types/react-dom@17.0.0":
   version "17.0.0"
@@ -8536,10 +8536,10 @@ q@^1.5.1:
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
 
-qs@6.9.6:
-  version "6.9.6"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.6.tgz#26ed3c8243a431b2924aca84cc90471f35d5a0ee"
-  integrity sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ==
+qs@6.9.7:
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
+  integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
 
 queue-microtask@^1.2.2:
   version "1.2.3"


### PR DESCRIPTION
# Type: patch

# What:  
- Bump qs dependency to 6.9.7 version to fix CVE-2022-24999 / GHSA-hrpp-h998-j3pp