### PR TITLE
[patch] Add new 'ValidationError' type describing error that can be returned upon unsuccessful validation 

### DIFF
--- a/.changeset/twelve-cows-mate.md
+++ b/.changeset/twelve-cows-mate.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Add new 'ValidationError' type describing error that can be returned upon unsuccessful validation of single voucher or in case of stacked validations. Add this new interface to 'StackableRedeemableResultResponse' and 'ValidationsValidateVoucherResponse' types

--- a/packages/sdk/src/types/Stackable.ts
+++ b/packages/sdk/src/types/Stackable.ts
@@ -5,6 +5,7 @@ import { ApplicableToResultList } from './ApplicableTo'
 import { DiscountVouchersTypes, DiscountVouchersEffectTypes, DiscountUnitVouchersEffectTypes } from './DiscountVoucher'
 import { SimpleProduct, SimpleSku } from './Products'
 import { LoyaltyPointsTransfer } from './Loyalties'
+import { ValidationError } from './ValidationError'
 
 type ExpandOption = 'order' | 'redeemable' | 'redemption'
 
@@ -58,7 +59,7 @@ export interface StackableRedeemableResultResponse {
 	discount?: StackableRedeemableResultDiscount
 	gift?: StackableRedeemableResultGift
 	loyalty_card?: StackableRedeemableResultLoyaltyCard
-	error?: any
+	error?: ValidationError
 }
 
 export interface StackableRedeemableResponse {

--- a/packages/sdk/src/types/ValidationError.ts
+++ b/packages/sdk/src/types/ValidationError.ts
@@ -1,0 +1,7 @@
+export interface ValidationError {
+	code?: number
+	key?: number
+	message: string
+	details?: string
+	request_id?: string
+}

--- a/packages/sdk/src/types/Validations.ts
+++ b/packages/sdk/src/types/Validations.ts
@@ -3,6 +3,7 @@ import { CustomersCreateBody } from './Customers'
 import { StackableOptions, StackableRedeemableParams, StackableRedeemableResponse } from './Stackable'
 import { ValidationSessionParams, ValidationSessionResponse } from './ValidateSession'
 import { ApplicableToResultList } from './ApplicableTo'
+import { ValidationError } from './ValidationError'
 
 import { OrdersItem, OrdersCreate, OrdersCreateResponse } from './Orders'
 import { PromotionsValidateParams } from './Promotions'
@@ -63,6 +64,7 @@ export interface ValidationsValidateVoucherResponse {
 	start_date?: string
 	expiration_date?: string
 	tracking_id: string
+	error?: ValidationError
 }
 
 export interface ValidationsValidateStackableParams {


### PR DESCRIPTION
# Related issue:
https://github.com/voucherifyio/voucherify-js-sdk/issues/176

# Change type: 
Patch

# Changes:  
- New `ValidationError` typed interface
- Changed `error` property in `StackableRedeemableResultResponse` type from `any` to typed `ValidationError` type - it should not break anything since all returned fields should be present in `ValidationError` type
- Added new `error` property to `ValidationsValidateVoucherResponse` type