### PR TITLE
fix: add assets to issue voucher response type

### DIFF
--- a/.changeset/green-readers-exist.md
+++ b/.changeset/green-readers-exist.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Add 'assets' from VouchersResponse to CampaignsAddVoucherResponse type

--- a/packages/sdk/src/types/Campaigns.ts
+++ b/packages/sdk/src/types/Campaigns.ts
@@ -141,6 +141,7 @@ export type CampaignsAddVoucherResponse = Pick<
 	| 'active'
 	| 'additional_info'
 	| 'metadata'
+	| 'assets'
 >
 
 export type CampaignsAddCertainVoucherResponse = CampaignsAddVoucherResponse


### PR DESCRIPTION
`assets` field is currently missing from the return type of `campaigns.addVoucher` method, which in reality the SDK returns the field.