### PR TITLE
[patch] Add active field to PromotionTier and add promotion_tier property to possible redeemables

### DIFF
--- a/.changeset/spicy-crews-fly.md
+++ b/.changeset/spicy-crews-fly.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Add 'active' field to 'PromotionTier' interface. Add 'PromotionTierRedeemDetailsSimple' and 'PromotionTierRedeemDetails' types and reuse them in 'RedemptionsRedeemResponse' so that 'RedemptionsRedeemStackableRedemptionResult' can return promotion_tier property

--- a/packages/sdk/src/types/PromotionTiers.ts
+++ b/packages/sdk/src/types/PromotionTiers.ts
@@ -34,6 +34,7 @@ export interface PromotionTier {
 	}
 	hierarchy: number
 	metadata?: Record<string, any>
+	active?: boolean
 }
 
 export interface PromotionTiersListAllParams {
@@ -104,6 +105,27 @@ export interface PromotionTiersRedeemResponse {
 				total_amount: number
 				total_discount_amount: number
 			}
+		}
+	}
+}
+
+export interface PromotionTierRedeemDetailsSimple {
+	id: string
+	name: string
+	banner?: string
+	campaign: {
+		id: string
+	}
+}
+
+export type PromotionTierRedeemDetails = PromotionTier & {
+	summary: {
+		redemptions: {
+			total_redeemed: number
+		}
+		orders: {
+			total_amount: number
+			total_discount_amount: number
 		}
 	}
 }

--- a/packages/sdk/src/types/Redemptions.ts
+++ b/packages/sdk/src/types/Redemptions.ts
@@ -5,6 +5,7 @@ import { VouchersResponse } from './Vouchers'
 import { GiftRedemptionParams } from './Gift'
 import { ValidationSessionParams, ValidationSessionReleaseParams } from './ValidateSession'
 import { StackableOptions, StackableRedeemableParams } from './Stackable'
+import { PromotionTierRedeemDetailsSimple, PromotionTierRedeemDetails } from './PromotionTiers'
 
 export interface RedemptionsRedeemBody {
 	tracking_id?: string
@@ -35,6 +36,7 @@ export interface RedemptionsRedeemResponse {
 	loyalty_card?: {
 		points: number
 	}
+	promotion_tier?: PromotionTierRedeemDetailsSimple | PromotionTierRedeemDetails
 	failure_code?: string
 	failure_message?: string
 }


### PR DESCRIPTION
# Related issues:
https://github.com/voucherifyio/voucherify-js-sdk/issues/193
https://github.com/voucherifyio/voucherify-js-sdk/issues/194

# Change type:
Patch

# Changes:  
- Added `active` field to `PromotionTier`
- Added new `PromotionTierRedeemDetailsSimple` interface
- Added new `PromotionTierRedeemDetails` type
- Union of `PromotionTierRedeemDetailsSimple` and `PromotionTierRedeemDetails` can now be returned as part of new optional property `promotion_tier` of `RedemptionsRedeemResponse` interface - thanks to that now API Response from redeem stackable contains correct typing for `promotion_tier` in `redeemables`