### PR TITLE
[minor] Add typing to return value of campaigns.list method

### DIFF
--- a/.changeset/bright-goats-breathe.md
+++ b/.changeset/bright-goats-breathe.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': minor
+---
+
+Add 'CampaignsListResponse' type to return value of campaigns.list method

--- a/packages/sdk/src/Campaigns.ts
+++ b/packages/sdk/src/Campaigns.ts
@@ -68,6 +68,6 @@ export class Campaigns {
 	 * @see https://docs.voucherify.io/reference/list-campaigns
 	 */
 	public list(params: T.CampaignsListParams = {}) {
-		return this.client.get('/campaigns', params)
+		return this.client.get<T.CampaignsListResponse>('/campaigns', params)
 	}
 }


### PR DESCRIPTION
# Related issues:
https://github.com/voucherifyio/voucherify-js-sdk/issues/201

# Change type:
Minor
**Why minor?**
Some people might already added their own typing to `campaings.list` method due to lack of our own typing. Feels like making it `patch` would not be correct move, at the same time this is not breaking change since typing was never provided in first place. Unfortunately we overlooked this.

# Changes:
- Added typing to return value of `campaigns.list` SDK method