### PR TITLE
Fixed typo in spellings of CANCELED

### DIFF
--- a/.changeset/old-spiders-begin.md
+++ b/.changeset/old-spiders-begin.md
@@ -1,5 +1,5 @@
 ---
-'@voucherify/sdk': major
+'@voucherify/sdk': patch
 ---
 
 Fixed minor typos in types for Order

--- a/.changeset/old-spiders-begin.md
+++ b/.changeset/old-spiders-begin.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': major
+---
+
+Fixed minor typos in types for Order

--- a/packages/sdk/src/types/Orders.ts
+++ b/packages/sdk/src/types/Orders.ts
@@ -35,7 +35,7 @@ export interface OrdersItem {
 
 export interface OrdersCreate {
 	source_id?: string
-	status?: 'CREATED' | 'PAID' | 'CANCELLED' | 'FULFILLED'
+	status?: 'CREATED' | 'PAID' | 'CANCELED' | 'FULFILLED'
 	customer?: CustomerRequest
 	amount?: number
 	discount_amount?: number
@@ -69,7 +69,7 @@ export type OrdersGetResponse = OrdersCreateResponse
 export interface OrdersUpdate {
 	id: string
 	source_id?: string
-	status?: 'CREATED' | 'PAID' | 'CANCELLED' | 'FULFILLED'
+	status?: 'CREATED' | 'PAID' | 'CANCELED' | 'FULFILLED'
 	items?: OrdersItem[]
 	amount?: number
 	discount_amount?: number

--- a/packages/sdk/src/types/PromotionTiers.ts
+++ b/packages/sdk/src/types/PromotionTiers.ts
@@ -70,7 +70,7 @@ export interface PromotionTiersRedeemParams {
 		source_id?: string
 		amount?: number
 		items?: OrdersItem[]
-		status?: 'CREATED' | 'PAID' | 'CANCELLED' | 'FULFILLED'
+		status?: 'CREATED' | 'PAID' | 'CANCELED' | 'FULFILLED'
 		metadata?: Record<string, any>
 	}
 	metadata?: Record<string, any>


### PR DESCRIPTION
Currently the API supports only CANCELED and not CANCELLED. This PR fixes the SDK to send correct key