### PR TITLE
[patch] Add missing properties to ValidationsValidateVoucherResponse interface

### DIFF
--- a/.changeset/fast-peaches-smash.md
+++ b/.changeset/fast-peaches-smash.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Added 'metadata' property to 'order' object in 'ValidationsValidateVoucherResponse' inteface. Added 'session' property to 'ValidationsValidateVoucherResponse' interface

--- a/packages/sdk/src/types/Validations.ts
+++ b/packages/sdk/src/types/Validations.ts
@@ -60,7 +60,9 @@ export interface ValidationsValidateVoucherResponse {
 		initial_amount?: number
 		items_discount_amount?: number
 		items_applied_discount_amount?: number
+		metadata?: Record<string, any>
 	}
+	session?: ValidationSessionParams
 	start_date?: string
 	expiration_date?: string
 	tracking_id: string


### PR DESCRIPTION
# Related issue:
https://github.com/voucherifyio/voucherify-js-sdk/issues/213

# Change type:
Patch

# Changes:
- Added `metadata` property to `order` property in `ValidationsValidateVoucherResponse` interface
- Added `session` property to `ValidationsValidateVoucherResponse` interface