### PR TITLE
[patch] add missing '_formula' fields to Voucher types

### DIFF
--- a/.changeset/cool-eyes-learn.md
+++ b/.changeset/cool-eyes-learn.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+add amount_off_formula, percent_off_formula, unit_off_formula, and fixed_amount_formula fields to Voucher types: DiscountAmount, DiscountPercent, DiscountUnit, DiscountFixed, VoucherDiscount, and StackableRedeemableResultDiscount

--- a/packages/sdk/src/types/DiscountVoucher.ts
+++ b/packages/sdk/src/types/DiscountVoucher.ts
@@ -43,6 +43,7 @@ interface SimpleProductDiscountUnit {
 export interface DiscountUnit {
 	type?: DiscountVouchersTypesEnum.UNIT
 	unit_off?: number
+	unit_off_formula?: string
 	effect?: DiscountUnitVouchersEffectTypes
 	unit_type?: string
 	product?: SimpleProductDiscountUnit
@@ -52,17 +53,20 @@ export interface DiscountUnit {
 export interface DiscountAmount {
 	type?: DiscountVouchersTypesEnum.AMOUNT
 	amount_off?: number
+	amount_off_formula?: string
 	effect?: DiscountAmountVouchersEffectTypes
 }
 
 export interface DiscountPercent {
 	type?: DiscountVouchersTypesEnum.PERCENT
 	percent_off?: number
+	percent_off_formula?: string
 	amount_limit?: number
 	effect?: DiscountPercentVouchersEffectTypes
 }
 export interface DiscountFixed {
 	type?: DiscountVouchersTypesEnum.FIXED
 	fixed_amount?: number
+	fixed_amount_formula?: string
 	effect?: DiscountFixedVouchersEffectTypes
 }

--- a/packages/sdk/src/types/Distributions.ts
+++ b/packages/sdk/src/types/Distributions.ts
@@ -19,9 +19,12 @@ type OrderType =
 export interface VoucherDiscount {
 	type: 'UNIT' | 'AMOUNT' | 'DISCOUNT'
 	unit_off?: number
+	unit_off_formula?: string
 	effect?: string
 	amount_off?: number
+	amount_off_formula?: string
 	percent_off?: number
+	percent_off_formula?: string
 	amount_limit?: number
 }
 

--- a/packages/sdk/src/types/Stackable.ts
+++ b/packages/sdk/src/types/Stackable.ts
@@ -36,10 +36,14 @@ export interface StackableRedeemableResultDiscount {
 	type: DiscountVouchersTypes
 	effect: DiscountVouchersEffectTypes
 	amount_off?: number
+	amount_off_formula?: string
 	percent_off?: number
+	percent_off_formula?: string
 	amount_limit?: number
 	fixed_amount?: number
+	fixed_amount_formula?: string
 	unit_off?: number
+	unit_off_formula?: string
 	unit_type?: string
 	sku?: SimpleSku
 	product?: SimpleProduct


### PR DESCRIPTION
# Change type:

**PATCH**

# Changes

- add `amount_off_formula`, `percent_off_formula`, `unit_off_formula`, and `fixed_amount_formula` fields to Voucher types: `DiscountAmount`, `DiscountPercent`, `DiscountUnit`, `DiscountFixed`, `VoucherDiscount`, and `StackableRedeemableResultDiscount`
