### PR TITLE
[patch] Add option to pass timeout to VoucherifyServerSide client and VoucherifyClientSide client

### DIFF
--- a/.changeset/modern-impalas-shake.md
+++ b/.changeset/modern-impalas-shake.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Add optional timeoutMs option to VoucherifyServerSide and VoucherifyClientSide classes defiing timeout in miliseconds after which Axios is going to abort the request. By default this is equal to 0 meaining that there is no timeout beside default Voucherify's Load balancer timeout which is set to 3 minutes

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -131,6 +131,7 @@ const client = VoucherifyServerSide({
 	apiVersion: 'v2018-08-01', // optional
 	channel: 'e-commerce', // optional
 	customHeaders: { "MY_CUSTOM_HEADER": "my_value" } // optional
+  timeoutMs: 10000 // optional
 })
 ```
 
@@ -1214,6 +1215,7 @@ const client = VoucherifyClientSide({
 	apiUrl: 'https://<region>.api.voucherify.io', // optional
 	origin: 'example.com', // read more below
 	customHeaders: { "MY_CUSTOM_HEADER": "my_value" } // optional
+  timeoutMs: 10000 // optional
 })
 ```
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -131,7 +131,7 @@ const client = VoucherifyServerSide({
 	apiVersion: 'v2018-08-01', // optional
 	channel: 'e-commerce', // optional
 	customHeaders: { "MY_CUSTOM_HEADER": "my_value" } // optional
-  timeoutMs: 10000 // optional
+	timeoutMs: 10000 // optional
 })
 ```
 
@@ -1215,7 +1215,7 @@ const client = VoucherifyClientSide({
 	apiUrl: 'https://<region>.api.voucherify.io', // optional
 	origin: 'example.com', // read more below
 	customHeaders: { "MY_CUSTOM_HEADER": "my_value" } // optional
-  timeoutMs: 10000 // optional
+	timeoutMs: 10000 // optional
 })
 ```
 

--- a/packages/sdk/src/RequestController.ts
+++ b/packages/sdk/src/RequestController.ts
@@ -8,6 +8,7 @@ export interface RequestControllerOptions {
 	basePath: string
 	headers: Record<string, any>
 	exposeErrorCause: boolean
+	timeoutMs: number
 }
 
 /**
@@ -21,14 +22,16 @@ export class RequestController {
 	private lastResponseHeaders: Record<string, string>
 	private isLastResponseHeadersSet: boolean
 	private exposeErrorCause: boolean
+	private timeoutMs: number
 
-	constructor({ basePath, baseURL, headers, exposeErrorCause }: RequestControllerOptions) {
+	constructor({ basePath, baseURL, headers, exposeErrorCause, timeoutMs }: RequestControllerOptions) {
 		this.basePath = basePath
 		this.baseURL = baseURL
 		this.headers = headers
 		this.exposeErrorCause = exposeErrorCause
 		this.lastResponseHeaders = {}
 		this.isLastResponseHeadersSet = false
+		this.timeoutMs = timeoutMs
 
 		this.request = axios.create({
 			baseURL: `${this.baseURL}/${this.basePath}/`,
@@ -71,6 +74,7 @@ export class RequestController {
 			paramsSerializer: function (params) {
 				return Qs.stringify(params)
 			},
+			timeout: this.timeoutMs,
 		})
 		this.setLastResponseHeaders(response.headers)
 		return response.data
@@ -87,17 +91,18 @@ export class RequestController {
 				return Qs.stringify(params)
 			},
 			headers,
+			timeout: this.timeoutMs,
 		})
 		this.setLastResponseHeaders(response.headers)
 		return response.data
 	}
 	public async put<T>(path: string, body: Record<string, any>, params?: Record<string, any>): Promise<T> {
-		const response = await this.request.put<T>(path, body, { params })
+		const response = await this.request.put<T>(path, body, { params, timeout: this.timeoutMs })
 		this.setLastResponseHeaders(response.headers)
 		return response.data
 	}
 	public async delete<T>(path: string, params?: Record<string, any>): Promise<T> {
-		const response = await this.request.delete<T>(path, { params })
+		const response = await this.request.delete<T>(path, { params, timeout: this.timeoutMs })
 		this.setLastResponseHeaders(response.headers)
 		return response.data
 	}

--- a/packages/sdk/src/VoucherifyClientSide.ts
+++ b/packages/sdk/src/VoucherifyClientSide.ts
@@ -83,6 +83,10 @@ export interface VoucherifyClientSideOptions {
 	 * The original Axios error will be included in cause property of VoucherifyError
 	 */
 	exposeErrorCause?: boolean
+	/**
+	 * Optionally, you can set timeout in miliseconds. After this time request will be aborted. By default Voucherify's API has timeout value of 3 minutes.
+	 */
+	timeoutMs?: number
 }
 interface VoucherifyCustomerHeaders {
 	'X-Client-Application-Id': string
@@ -117,6 +121,7 @@ export function VoucherifyClientSide(options: VoucherifyClientSideOptions): Clie
 		baseURL: options.apiUrl ?? 'https://api.voucherify.io',
 		headers,
 		exposeErrorCause: options.exposeErrorCause ?? false,
+		timeoutMs: options.timeoutMs ?? 0,
 	})
 
 	return new ClientSide(client, options.trackingId)

--- a/packages/sdk/src/VoucherifyServerSide.ts
+++ b/packages/sdk/src/VoucherifyServerSide.ts
@@ -104,6 +104,10 @@ export interface VoucherifyServerSideOptions {
 	 * The original Axios error will be included in cause property of VoucherifyError
 	 */
 	exposeErrorCause?: boolean
+	/**
+	 * Optionally, you can set timeout in miliseconds. After this time request will be aborted. By default Voucherify's API has timeout value of 3 minutes.
+	 */
+	timeoutMs?: number
 }
 interface VoucherifyServerSideHeaders {
 	'X-App-Id': string
@@ -169,6 +173,7 @@ export function VoucherifyServerSide(options: VoucherifyServerSideOptions) {
 		baseURL: options.apiUrl ?? 'https://api.voucherify.io',
 		headers,
 		exposeErrorCause: options.exposeErrorCause ?? false,
+		timeoutMs: options.timeoutMs ?? 0,
 	})
 	const asyncActions = new AsyncActions(client)
 	const balance = new Balance(client)


### PR DESCRIPTION
# Change type:
Patch

# Changes:
- Added optional `timeoutMs` property to `VoucherifyServerSide` and `VoucherifyClientSide` classes allowing developers to set custom timeout in milliseconds after which Axios will abort the request. Fallback is set to `0` which means `No timeout`. In such case default timeout of 3 minutes is used which is what is set on Voucherify's Load Balancers

# Examples of usage:
**Server Side Client:**
```
const client = VoucherifyServerSide({
	applicationId: 'YOUR-APPLICATION-ID',
	secretKey: 'YOUR-SECRET-KEY',
	timeoutMs: 10000
})
```

**Client Side Client:**
```
const client = VoucherifyClientSide({
	clientApplicationId: 'YOUR-APPLICATION-ID',
	clientSecretKey: 'YOUR-CLIENT-SECRET-KEY',
	timeoutMs: 10000
})
```
