### PR TITLE
Pz/types 006 - LoyaltyRewardAssignment (MAJOR) - no tests

### DIFF
--- a/.changeset/tidy-comics-ironman.md
+++ b/.changeset/tidy-comics-ironman.md
@@ -1,0 +1,12 @@
+---
+'@voucherify/sdk': major
+---
+
+Added support for new endpoints and adding missing types in rewards api.
+- Added support for new endpoints: `/loyalties/{campaignId}/rewards/{assignmentId}` and `/loyalties/${campaignId}/tiers/{tierId}/rewards` [(example available in readme.md)](..%2F..%2Fpackages%2Fsdk%2FREADME.md)
+- New exported types/interfaces in `Loyalties.ts`: `ListLoyaltyTierRewardResponse`, `LoyaltyTierRewardObject`, `LoyaltyTierRewardRewardObject`, `LoyaltyTierRewardRewardObjectCommon`, `LoyaltyTierRewardRewardCampaignObject`, `LoyaltyTierRewardRewardCoinObject`, `LoyaltyTierRewardRewardMaterialObject`, `RewardParametersCampaign`, `RewardParametersCoin`, `RewardParametersProduct` and `GetRewardAssignmentsResponse`
+- New exported types/interfaces in `Rewards.ts`: `RewardsAssignmentObjectCommon`
+- **(BREAKING CHANGE)** Interface `RewardsAssignmentObject` was changed. Few values are now required, uses union type.
+- **(BREAKING CHANGE)** Interface `RewardsCreateAssignment` was changed. Few values are now required. **If previously you send data without required parameters, you failed anyway.**
+- **(BREAKING CHANGE)** Interface `RewardsCreateAssignmentResponse` was changed. Type of value `updated_at` is always `null`.
+- **(BREAKING CHANGE)** Interface `RewardsUpdateAssignmentResponse` was changed. Type of value `updated_at` is always `string`.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -959,6 +959,7 @@ Methods are provided within `client.loyalties.*` namespace.
 - [Create Loyalty Program Reward Assignment](#create-loyalty-program-reward-assignment)
 - [Update Loyalty Program Reward Assignment](#update-loyalty-program-reward-assignment)
 - [Delete Loyalty Program Reward Assignment](#delete-loyalty-program-reward-assignment)
+- [Get Loyalty Program Reward Assignment](#get-loyalty-program-reward-assignment)
 - [List Loyalty Program Reward Assignments](#list-loyalty-program-reward-assignments)
 - [Create Loyalty Program Earning Rules](#create-loyalty-program-earning-rules)
 - [Update Loyalty Program Earning Rule](#update-loyalty-program-earning-rule)
@@ -966,10 +967,11 @@ Methods are provided within `client.loyalties.*` namespace.
 - [List Loyalty Program Earning Rules](#list-loyalty-program-earning-rules)
 - [Create Loyalty Program Member](#create-loyalty-program-member)
 - [Get Loyalty Program Member](#get-loyalty-program-member)
-- [List Loyalty Program Members](#list-loyalty-members)
+- [List Loyalty Program Members](#list-loyalty-program-members)
 - [Get Loyalty Program Member Activities](#get-loyalty-program-member-activities)
 - [Add Loyalty Card Balance](#add-loyalty-card-balance)
 - [Redeem Loyalty Card](#redeem-loyalty-card)
+- [List Loyalty Tier Rewards](#list-loyalty-tier-rewards)
 
 #### [Create Loyalty Program](https://docs.voucherify.io/reference/create-loyalty-program)
 
@@ -1019,6 +1021,13 @@ client.loyalties.updateRewardAssignment(campaignId, assignment)
 ```javascript
 client.loyalties.deleteRewardAssignment(campaignId, assignmentId)
 ```
+
+#### [Get Loyalty Program Reward Assignment](https://docs.voucherify.io/reference/get-reward-assignment-1)
+
+```javascript
+client.loyalties.getRewardAssignment(campaignId, assignmentId)
+```
+
 
 #### [List Loyalty Program Reward Assignments](https://docs.voucherify.io/reference/list-reward-assignments-1)
 
@@ -1096,6 +1105,12 @@ client.loyalties.redeemReward(campaignId, memberId, params)
 `memberId` referrers to Loyalty Card code.
 
 When redeeming reward with type `COIN` you need to provide additional `order` object in the `params`
+
+#### [List Loyalty Tier Rewards](https://docs.voucherify.io/reference/list-loyalty-tier-rewards)
+
+```javascript
+client.loyalties.listLoyaltyTierReward(campaignId, tierId)
+```
 
 ---
 

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1109,7 +1109,7 @@ When redeeming reward with type `COIN` you need to provide additional `order` ob
 #### [List Loyalty Tier Rewards](https://docs.voucherify.io/reference/list-loyalty-tier-rewards)
 
 ```javascript
-client.loyalties.listLoyaltyTierReward(campaignId, tierId)
+client.loyalties.listLoyaltyTierRewards(campaignId, tierId)
 ```
 
 ---

--- a/packages/sdk/src/Loyalties.ts
+++ b/packages/sdk/src/Loyalties.ts
@@ -70,6 +70,14 @@ export class Loyalties {
 		return this.client.delete(`/loyalties/${encode(campaignId)}/rewards/${assignmentId}`)
 	}
 	/**
+	 * @see https://docs.voucherify.io/reference/get-reward-assignment-1
+	 */
+	public getRewardAssignment(campaignId: string, assignmentId: string) {
+		return this.client.get<T.GetRewardAssignmentsResponse>(
+			`/loyalties/${encode(campaignId)}/rewards/${encode(assignmentId)}`,
+		)
+	}
+	/**
 	 * @see https://docs.voucherify.io/reference/list-earning-rules
 	 */
 	public listEarningRules(campaignId: string, params: T.LoyaltiesListEarningRulesParams = {}) {
@@ -144,6 +152,14 @@ export class Loyalties {
 		return this.client.post<T.LoyaltiesRedeemRewardResponse>(
 			`/loyalties/${encode(campaignId)}/members/${encode(memberId)}/redemption`,
 			params,
+		)
+	}
+	/**
+	 * @see https://docs.voucherify.io/reference/list-loyalty-tier-rewards
+	 */
+	public listLoyaltyTierReward(campaignId: string, tierId: string) {
+		return this.client.get<T.ListLoyaltyTierRewardResponse>(
+			`/loyalties/${encode(campaignId)}/tiers/${encode(tierId)}/rewards`,
 		)
 	}
 }

--- a/packages/sdk/src/Loyalties.ts
+++ b/packages/sdk/src/Loyalties.ts
@@ -157,8 +157,8 @@ export class Loyalties {
 	/**
 	 * @see https://docs.voucherify.io/reference/list-loyalty-tier-rewards
 	 */
-	public listLoyaltyTierReward(campaignId: string, tierId: string) {
-		return this.client.get<T.ListLoyaltyTierRewardResponse>(
+	public listLoyaltyTierRewards(campaignId: string, tierId: string) {
+		return this.client.get<T.ListLoyaltyTierRewardsResponse>(
 			`/loyalties/${encode(campaignId)}/tiers/${encode(tierId)}/rewards`,
 		)
 	}

--- a/packages/sdk/src/types/Loyalties.ts
+++ b/packages/sdk/src/types/Loyalties.ts
@@ -5,6 +5,8 @@ import { SimpleCustomer } from './Customers'
 import { ValidationRulesCreateAssignmentResponse } from './ValidationRules'
 import { VouchersResponse } from './Vouchers'
 
+import { RewardsAssignmentObject } from './Rewards'
+
 interface LoyaltiesVoucher {
 	code_config?: {
 		length?: number
@@ -496,4 +498,74 @@ export interface LoyaltiesRedeemRewardResponse {
 export interface LoyaltyPointsTransfer {
 	code: string
 	points: number
+}
+
+export type GetRewardAssignmentsResponse = RewardsAssignmentObject
+
+export interface ListLoyaltyTierRewardResponse {
+	object: 'list'
+	data_ref: 'data'
+	data: LoyaltyTierRewardObject[]
+	total: number
+}
+
+export interface LoyaltyTierRewardObject {
+	reward: LoyaltyTierRewardRewardObject
+	assignment: RewardsAssignmentObject
+	object: 'loyalty_tier_reward'
+}
+
+export type LoyaltyTierRewardRewardObject = LoyaltyTierRewardRewardObjectCommon &
+	(LoyaltyTierRewardRewardCampaignObject | LoyaltyTierRewardRewardCoinObject | LoyaltyTierRewardRewardMaterialObject)
+
+export interface LoyaltyTierRewardRewardObjectCommon {
+	id: string
+	name: string | null
+	redeemed: number | null
+	stock: number | null
+	attributes?: {
+		image_url?: string
+		description?: string
+	}
+	created_at: string
+	updated_at: string | null
+	metadata: Record<string, any>
+	object: 'reward'
+}
+
+export interface LoyaltyTierRewardRewardCampaignObject {
+	type: 'CAMPAIGN'
+	parameters: {
+		campaign: RewardParametersCampaign
+	}
+}
+
+export interface LoyaltyTierRewardRewardCoinObject {
+	type: 'COIN'
+	parameters: {
+		coin: RewardParametersCoin
+	}
+}
+
+export interface LoyaltyTierRewardRewardMaterialObject {
+	type: 'MATERIAL'
+	parameters: {
+		product: RewardParametersProduct
+	}
+}
+
+export interface RewardParametersCampaign {
+	id: string
+	balance?: number
+	type: string
+}
+
+export interface RewardParametersCoin {
+	exchange_ratio: number
+	points_ratio: number
+}
+
+export interface RewardParametersProduct {
+	id?: string
+	sku_id?: string
 }

--- a/packages/sdk/src/types/Loyalties.ts
+++ b/packages/sdk/src/types/Loyalties.ts
@@ -502,7 +502,7 @@ export interface LoyaltyPointsTransfer {
 
 export type GetRewardAssignmentsResponse = RewardsAssignmentObject
 
-export interface ListLoyaltyTierRewardResponse {
+export interface ListLoyaltyTierRewardsResponse {
 	object: 'list'
 	data_ref: 'data'
 	data: LoyaltyTierRewardObject[]

--- a/packages/sdk/src/types/Rewards.ts
+++ b/packages/sdk/src/types/Rewards.ts
@@ -90,19 +90,22 @@ export type RewardsUpdate = Omit<RewardsCreate, 'type'> & { id: string }
 
 export type RewardsUpdateResponse = RewardsCreateResponse
 
-export interface RewardsAssignmentObject {
+export interface RewardsAssignmentObjectCommon {
 	id: string
 	reward_id: string
-	related_object_id?: string
-	related_object_type?: string
-	parameters?: {
-		loyalty?: {
-			points: number
+	related_object_id: string
+	related_object_type: 'campaign'
+	parameters: {
+		loyalty: {
+			points?: number
 		}
 	}
 	created_at: string
-	updated_at?: string
 	object: 'reward_assignment'
+}
+
+export interface RewardsAssignmentObject extends RewardsAssignmentObjectCommon {
+	updated_at: string | null
 }
 
 export interface RewardsListAssignmentsParams {
@@ -118,19 +121,19 @@ export interface RewardsListAssignmentsResponse {
 }
 
 export interface RewardsCreateAssignment {
-	campaign?: string
-	parameters?: {
-		loyalty?: {
-			points: number
+	campaign: string
+	parameters: {
+		loyalty: {
+			points?: number
 		}
 	}
 }
 
-export type RewardsCreateAssignmentResponse = RewardsAssignmentObject
+export type RewardsCreateAssignmentResponse = RewardsAssignmentObjectCommon & { updated_at: null }
 
-export type RewardsUpdateAssignment = RewardsCreateAssignment & { id: string }
+export type RewardsUpdateAssignment = Partial<RewardsCreateAssignment> & { id: string }
 
-export type RewardsUpdateAssignmentResponse = RewardsAssignmentObject
+export type RewardsUpdateAssignmentResponse = RewardsAssignmentObjectCommon & { updated_at: string }
 
 export interface RewardRedemptionParams {
 	points?: number


### PR DESCRIPTION
---
'@voucherify/sdk': major
---

Added support for new endpoints and adding missing types in rewards api.
- Added support for new endpoints: `/loyalties/{campaignId}/rewards/{assignmentId}` and `/loyalties/${campaignId}/tiers/{tierId}/rewards` [(example available in readme.md)](..%2F..%2Fpackages%2Fsdk%2FREADME.md)
- New exported types/interfaces in `Loyalties.ts`: `ListLoyaltyTierRewardResponse`, `LoyaltyTierRewardObject`, `LoyaltyTierRewardRewardObject`, `LoyaltyTierRewardRewardObjectCommon`, `LoyaltyTierRewardRewardCampaignObject`, `LoyaltyTierRewardRewardCoinObject`, `LoyaltyTierRewardRewardMaterialObject`, `RewardParametersCampaign`, `RewardParametersCoin`, `RewardParametersProduct` and `GetRewardAssignmentsResponse`
- New exported types/interfaces in `Rewards.ts`: `RewardsAssignmentObjectCommon`
- **(BREAKING CHANGE)** Interface `RewardsAssignmentObject` was changed. Few values are now required, uses union type.
- **(BREAKING CHANGE)** Interface `RewardsCreateAssignment` was changed. Few values are now required. **If previously you send data without required parameters, you failed anyway.**
- **(BREAKING CHANGE)** Interface `RewardsCreateAssignmentResponse` was changed. Type of value `updated_at` is always `null`.
- **(BREAKING CHANGE)** Interface `RewardsUpdateAssignmentResponse` was changed. Type of value `updated_at` is always `string`.
