### PR TITLE
Pz/types 005 - Exports

### DIFF
--- a/.changeset/tidy-king-sun.md
+++ b/.changeset/tidy-king-sun.md
@@ -1,5 +1,5 @@
 ---
-'@voucherify/sdk': major
+'@voucherify/sdk': minor
 ---
 
 Add support for endpoint `GET /exports`.

--- a/.changeset/tidy-king-sun.md
+++ b/.changeset/tidy-king-sun.md
@@ -1,0 +1,6 @@
+---
+'@voucherify/sdk': major
+---
+
+Add support for endpoint `GET /exports`.
+- New exported types/interfaces: `ExportsListRequestQuery`, `ExportsListResponseBody`, `ExportBase`, `ExportResourceResponse`, `FieldConditions`, `ExportVoucher`, `ExportVoucherFilters`, `ExportRedemption`, `ExportRedemptionFilters`, `ExportCustomer`, `ExportCustomerFilters`, `ExportPublication`, `ExportPublicationFilters`, `ExportOrder`, `ExportOrderFilters`, `ExportPointsExpiration`, `ExportPointsExpirationFilters`, `ExportVoucherTransactionsExpiration`, `ExportVoucherTransactionsFilters`, `Junction`, `FiltersCondition`, `ExportCustomerFields`, `ExportCustomerOrder`, `ExportPublicationFields`, `ExportPublicationOrder`, `ExportRedemptionFields`, `ExportRedemptionOrder`, `ExportVoucherFields`, `ExportVoucherOrder`, `ExportOrderFields`, `ExportOrderOrder`, `ExportPointsExpirationFields`, `ExportPointsExpirationOrder`, `ExportVoucherTransactionsFields`, `ExportVoucherTransactionsOrder`

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -348,6 +348,7 @@ client.campaigns.qualifications.examine(body, params)
 Methods are provided within `client.distributions.*` namespace.
 
 - [Create Export](#create-export)
+- [List Exports](#list-exports)
 - [Get Export](#get-export)
 - [Delete Export](#delete-export)
 - [List publications](#list-publications)
@@ -360,6 +361,12 @@ client.distributions.exports.create(exportObject)
 ```
 
 Check [the export object](https://docs.voucherify.io/v1/reference/the-export-object).
+
+#### [List Exports](https://docs.voucherify.io/reference/list-exports)
+
+```javascript
+client.distributions.exports.list()
+```
 
 #### [Get Export](https://docs.voucherify.io/reference/get-export)
 

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -41,6 +41,7 @@
 		"qs": "6.9.7"
 	},
 	"devDependencies": {
+		"utility-types": "3.10.0",
 		"dotenv": "16.3.1",
 		"csv-stringify": "6.4.0",
 		"@types/qs": "6.9.7"

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -41,7 +41,6 @@
 		"qs": "6.9.7"
 	},
 	"devDependencies": {
-		"utility-types": "3.10.0",
 		"dotenv": "16.3.1",
 		"csv-stringify": "6.4.0",
 		"@types/qs": "6.9.7"

--- a/packages/sdk/src/Exports.ts
+++ b/packages/sdk/src/Exports.ts
@@ -13,6 +13,12 @@ export class Exports {
 		return this.client.post<T.ExportsCreateResponse>('/exports', exportResource)
 	}
 	/**
+	 * @see https://docs.voucherify.io/reference/list-exports
+	 */
+	public list(query: T.ExportsListRequestQuery = {}) {
+		return this.client.get<T.ExportsListResponseBody>('/exports', query)
+	}
+	/**
 	 * @see https://docs.voucherify.io/reference/get-export
 	 */
 	public get(exportResourceId: string) {

--- a/packages/sdk/src/types/Exports.ts
+++ b/packages/sdk/src/types/Exports.ts
@@ -42,7 +42,7 @@ export interface ExportsListRequestQuery {
 export interface ExportsListResponseBody {
 	object: 'list'
 	data_ref: 'exports'
-	exports: ExportResourceResponse[]
+	exports: Export[]
 	total: number
 }
 
@@ -60,7 +60,7 @@ export interface ExportBase {
 	user_id: string | null
 }
 
-export type ExportResourceResponse = ExportBase &
+export type Export = ExportBase &
 	(
 		| ExportVoucher
 		| ExportRedemption

--- a/packages/sdk/src/types/Exports.ts
+++ b/packages/sdk/src/types/Exports.ts
@@ -1,5 +1,3 @@
-import { DeepReadonly } from 'utility-types'
-
 export interface ExportResource {
 	exported_object: 'voucher' | 'redemption' | 'publication' | 'customer'
 	parameters?: {
@@ -35,7 +33,423 @@ export type ExportsGetResponse = ExportsCreateResponse
 
 // 0-level types
 
-export type ExportsListRequestQuery = {}
-export type ExportsListResponseBody = {}
+export interface ExportsListRequestQuery {
+	limit?: number
+	order?: 'created_at' | '-created_at' | 'status' | '-status'
+	page?: number
+}
+
+export interface ExportsListResponseBody {
+	object: 'list'
+	data_ref: 'exports'
+	exports: ExportResourceResponse[]
+	total: number
+}
 
 // domain types
+
+export interface ExportBase {
+	id: string
+	object: 'export'
+	created_at: string
+	status: 'SCHEDULED' | 'IN_PROGRESS' | 'DONE' | 'ERROR'
+	channel?: string
+	result: {
+		url: string
+	} | null
+	user_id: string | null
+}
+
+export type ExportResourceResponse = ExportBase &
+	(
+		| ExportVoucher
+		| ExportRedemption
+		| ExportCustomer
+		| ExportPublication
+		| ExportOrder
+		| ExportPointsExpiration
+		| ExportVoucherTransactionsExpiration
+	)
+
+export type FieldConditions = { conditions?: Partial<Record<FiltersCondition, unknown>> }
+
+export interface ExportVoucher {
+	exported_object: 'voucher'
+	parameters: {
+		order?: ExportVoucherOrder
+		fields?: ExportVoucherFields[]
+		filters?: ExportVoucherFilters
+	}
+}
+
+export type ExportVoucherFilters = {
+	junction?: Junction
+} & Partial<Record<ExportVoucherFields, FieldConditions>>
+
+export interface ExportRedemption {
+	exported_object: 'redemption'
+	parameters: {
+		order?: ExportRedemptionOrder
+		fields?: ExportRedemptionFields[]
+		filters?: ExportRedemptionFilters
+	}
+}
+
+export type ExportRedemptionFilters = {
+	junction?: Junction
+} & Partial<Record<ExportRedemptionFields, FieldConditions>>
+
+export interface ExportCustomer {
+	exported_object: 'customer'
+	parameters: {
+		order?: ExportCustomerOrder
+		fields?: ExportCustomerFields[]
+		filters?: ExportCustomerFilters
+	}
+}
+
+export type ExportCustomerFilters = {
+	junction?: Junction
+} & Partial<Record<ExportCustomerFields, FieldConditions>>
+
+export interface ExportPublication {
+	exported_object: 'publication'
+	parameters: {
+		order?: ExportPublicationOrder
+		fields?: ExportPublicationFields[]
+		filters?: ExportPublicationFilters
+	}
+}
+
+export type ExportPublicationFilters = {
+	junction?: Junction
+} & Partial<Record<ExportPublicationFields, FieldConditions>>
+
+export interface ExportOrder {
+	exported_object: 'order'
+	parameters: {
+		order?: ExportOrderOrder
+		fields?: ExportOrderFields[]
+		filters?: ExportOrderFilters
+	}
+}
+
+export type ExportOrderFilters = {
+	junction?: Junction
+} & Partial<Record<ExportOrderFields, FieldConditions>>
+
+export interface ExportPointsExpiration {
+	exported_object: 'points_expiration'
+	parameters: {
+		order?: ExportPointsExpirationOrder
+		fields?: ExportPointsExpirationFields[]
+		filters?: ExportPointsExpirationFilters
+	}
+}
+
+export type ExportPointsExpirationFilters = {
+	junction?: Junction
+} & Partial<Record<ExportPointsExpirationFields, FieldConditions>>
+
+export interface ExportVoucherTransactionsExpiration {
+	exported_object: 'voucher_transactions'
+	parameters: {
+		order?: ExportVoucherTransactionsOrder
+		fields?: ExportVoucherTransactionsFields[]
+		filters?: ExportVoucherTransactionsFilters
+	}
+}
+
+export type ExportVoucherTransactionsFilters = {
+	junction?: Junction
+} & Partial<Record<ExportVoucherTransactionsFields, FieldConditions>>
+
+export type Junction = 'and' | 'AND' | 'or' | 'OR'
+
+export type FiltersCondition =
+	| '$in'
+	| '$not_in'
+	| '$is'
+	| '$is_days_ago'
+	| '$is_days_in_future'
+	| '$is_not'
+	| '$has_value'
+	| '$is_unknown'
+	| '$contains'
+	| '$not_contain'
+	| '$starts_with'
+	| '$ends_with'
+	| '$more_than'
+	| '$less_than'
+	| '$more_than_ago'
+	| '$less_than_ago'
+	| '$more_than_future'
+	| '$less_than_future'
+	| '$more_than_equal'
+	| '$less_than_equal'
+	| '$after'
+	| '$before'
+	| '$count'
+	| '$count_less'
+	| '$count_more'
+
+export type ExportCustomerFields =
+	| 'name'
+	| 'id'
+	| 'description'
+	| 'email'
+	| 'source_id'
+	| 'created_at'
+	| 'address_city'
+	| 'address_state'
+	| 'address_line_1'
+	| 'address_line_2'
+	| 'address_country'
+	| 'address_postal_code'
+	| 'redemptions_total_redeemed'
+	| 'redemptions_total_failed'
+	| 'redemptions_total_succeeded'
+	| 'redemptions_total_rolled_back'
+	| 'redemptions_total_rollback_failed'
+	| 'redemptions_total_rollback_succeeded'
+	| 'orders_total_amount'
+	| 'orders_total_count'
+	| 'orders_average_amount'
+	| 'orders_last_order_amount'
+	| 'orders_last_order_date'
+	| 'loyalty_points'
+	| 'loyalty_referred_customers'
+	| 'updated_at'
+	| 'phone'
+	| 'birthday'
+	| 'metadata'
+	| 'birthdate'
+
+export type ExportCustomerOrder =
+	| ExportCustomerFields
+	| '-name'
+	| '-id'
+	| '-description'
+	| '-email'
+	| '-source_id'
+	| '-created_at'
+	| '-address_city'
+	| '-address_state'
+	| '-address_line_1'
+	| '-address_line_2'
+	| '-address_country'
+	| '-address_postal_code'
+	| '-redemptions_total_redeemed'
+	| '-redemptions_total_failed'
+	| '-redemptions_total_succeeded'
+	| '-redemptions_total_rolled_back'
+	| '-redemptions_total_rollback_failed'
+	| '-redemptions_total_rollback_succeeded'
+	| '-orders_total_amount'
+	| '-orders_total_count'
+	| '-orders_average_amount'
+	| '-orders_last_order_amount'
+	| '-orders_last_order_date'
+	| '-loyalty_points'
+	| '-loyalty_referred_customers'
+	| '-updated_at'
+	| '-phone'
+	| '-birthday'
+	| '-metadata'
+	| '-birthdate'
+
+export type ExportPublicationFields =
+	| 'voucher_code'
+	| 'customer_id'
+	| 'customer_source_id'
+	| 'date'
+	| 'channel'
+	| 'campaign'
+	| 'is_winner'
+	| 'metadata'
+
+export type ExportPublicationOrder =
+	| ExportPublicationFields
+	| '-voucher_code'
+	| '-customer_id'
+	| '-customer_source_id'
+	| '-date'
+	| '-channel'
+	| '-campaign'
+	| '-is_winner'
+	| '-metadata'
+
+export type ExportRedemptionFields =
+	| 'id'
+	| 'object'
+	| 'date'
+	| 'voucher_code'
+	| 'campaign'
+	| 'promotion_tier_id'
+	| 'customer_id'
+	| 'customer_source_id'
+	| 'customer_name'
+	| 'tracking_id'
+	| 'order_amount'
+	| 'gift_amount'
+	| 'loyalty_points'
+	| 'result'
+	| 'failure_code'
+	| 'failure_message'
+	| 'metadata'
+
+export type ExportRedemptionOrder =
+	| ExportRedemptionFields
+	| '-id'
+	| '-object'
+	| '-date'
+	| '-voucher_code'
+	| '-campaign'
+	| '-promotion_tier_id'
+	| '-customer_id'
+	| '-customer_source_id'
+	| '-customer_name'
+	| '-tracking_id'
+	| '-order_amount'
+	| '-gift_amount'
+	| '-loyalty_points'
+	| '-result'
+	| '-failure_code'
+	| '-failure_message'
+	| '-metadata'
+
+export type ExportVoucherFields =
+	| 'code'
+	| 'voucher_type'
+	| 'value'
+	| 'discount_type'
+	| 'campaign'
+	| 'category'
+	| 'start_date'
+	| 'expiration_date'
+	| 'gift_balance'
+	| 'loyalty_balance'
+	| 'redemption_quantity'
+	| 'redemption_count'
+	| 'active'
+	| 'qr_code'
+	| 'bar_code'
+	| 'metadata'
+	| 'id'
+	| 'is_referral_code'
+	| 'created_at'
+	| 'updated_at'
+	| 'validity_timeframe_interval'
+	| 'validity_timeframe_duration'
+	| 'validity_day_of_week'
+	| 'discount_amount_limit'
+	| 'campaign_id'
+	| 'additional_info'
+	| 'customer_id'
+	| 'discount_unit_type'
+	| 'discount_unit_effect'
+	| 'customer_source_id'
+
+export type ExportVoucherOrder =
+	| ExportVoucherFields
+	| '-code'
+	| '-voucher_type'
+	| '-value'
+	| '-discount_type'
+	| '-campaign'
+	| '-category'
+	| '-start_date'
+	| '-expiration_date'
+	| '-gift_balance'
+	| '-loyalty_balance'
+	| '-redemption_quantity'
+	| '-redemption_count'
+	| '-active'
+	| '-qr_code'
+	| '-bar_code'
+	| '-metadata'
+	| '-id'
+	| '-is_referral_code'
+	| '-created_at'
+	| '-updated_at'
+	| '-validity_timeframe_interval'
+	| '-validity_timeframe_duration'
+	| '-validity_day_of_week'
+	| '-discount_amount_limit'
+	| '-campaign_id'
+	| '-additional_info'
+	| '-customer_id'
+	| '-discount_unit_type'
+	| '-discount_unit_effect'
+	| '-customer_source_id'
+
+export type ExportOrderFields =
+	| 'id'
+	| 'source_id'
+	| 'created_at'
+	| 'updated_at'
+	| 'status'
+	| 'amount'
+	| 'discount_amount'
+	| 'items_discount_amount'
+	| 'total_discount_amount'
+	| 'total_amount'
+	| 'customer_id'
+	| 'referrer_id'
+	| 'metadata'
+
+export type ExportOrderOrder =
+	| ExportOrderFields
+	| '-id'
+	| '-source_id'
+	| '-created_at'
+	| '-updated_at'
+	| '-status'
+	| '-amount'
+	| '-discount_amount'
+	| '-items_discount_amount'
+	| '-total_discount_amount'
+	| '-total_amount'
+	| '-customer_id'
+	| '-referrer_id'
+	| '-metadata'
+
+export type ExportPointsExpirationFields = 'id' | 'campaign_id' | 'voucher_id' | 'points' | 'status' | 'expires_at'
+
+export type ExportPointsExpirationOrder =
+	| ExportPointsExpirationFields
+	| '-id'
+	| '-campaign_id'
+	| '-voucher_id'
+	| '-points'
+	| '-status'
+	| '-expires_at'
+
+export type ExportVoucherTransactionsFields =
+	| 'id'
+	| 'campaign_id'
+	| 'voucher_id'
+	| 'type'
+	| 'source_id'
+	| 'reason'
+	| 'source'
+	| 'balance'
+	| 'amount'
+	| 'related_transaction_id'
+	| 'created_at'
+	| 'details'
+
+export type ExportVoucherTransactionsOrder =
+	| ExportVoucherTransactionsFields
+	| '-id'
+	| '-campaign_id'
+	| '-voucher_id'
+	| '-type'
+	| '-source_id'
+	| '-reason'
+	| '-source'
+	| '-balance'
+	| '-amount'
+	| '-related_transaction_id'
+	| '-created_at'
+	| '-details'

--- a/packages/sdk/src/types/Exports.ts
+++ b/packages/sdk/src/types/Exports.ts
@@ -1,3 +1,5 @@
+import { DeepReadonly } from 'utility-types'
+
 export interface ExportResource {
 	exported_object: 'voucher' | 'redemption' | 'publication' | 'customer'
 	parameters?: {
@@ -30,3 +32,10 @@ export interface ExportsCreateResponse {
 }
 
 export type ExportsGetResponse = ExportsCreateResponse
+
+// 0-level types
+
+export type ExportsListRequestQuery = {}
+export type ExportsListResponseBody = {}
+
+// domain types

--- a/packages/sdk/test/exports.spec.ts
+++ b/packages/sdk/test/exports.spec.ts
@@ -1,0 +1,62 @@
+import { voucherifyClient as client } from './client'
+import { isoRegex } from './utils/isoRegex'
+import { ExportResourceResponse } from '@voucherify/sdk'
+
+describe('Exports API', () => {
+	it('Should create export, with no parameters', async () => {
+		const result = await client.distributions.exports.create({ exported_object: 'voucher' })
+		expect(result).toMatchObject({
+			id: expect.stringMatching(/^exp-*/),
+			object: 'export',
+			created_at: expect.stringMatching(isoRegex),
+			status: 'SCHEDULED',
+			channel: 'API',
+			exported_object: 'voucher',
+			parameters: {},
+			result: null,
+			user_id: null,
+		})
+	})
+
+	it('Should create export, with some parameters', async () => {
+		const request = {
+			exported_object: 'voucher' as const,
+			parameters: {
+				fields: ['id', 'code', 'voucher_type', 'value', 'discount_type'],
+				filters: { code: { conditions: { $is_unknown: true } } },
+			},
+		}
+		const result = await client.distributions.exports.create(request)
+		//we must narrow down result type, otherwise we will have hard time with 'parameters' type
+		expect(result.exported_object).toEqual(request.exported_object)
+		if (result.exported_object !== request.exported_object) {
+			return
+		}
+		//we need to use endpoint list, since only this endpoint has most complicated definition
+		const list = await client.distributions.exports.list()
+		const justExported = list.exports.find(_export => _export.id === result.id)
+		if (!justExported) {
+			return
+		}
+		//we must find out if 'fields' and 'filters' are defined, to figure out its value
+		expect(justExported.parameters.fields).toBeDefined()
+		if (!justExported.parameters.fields) {
+			return
+		}
+		expect(justExported.parameters.filters).toBeDefined()
+		if (!justExported.parameters.filters) {
+			return
+		}
+		expect(justExported as ExportResourceResponse).toMatchObject({
+			id: expect.stringMatching(/^exp-*/),
+			object: 'export',
+			created_at: expect.stringMatching(isoRegex),
+			status: expect.stringMatching(/.*/),
+			channel: 'API',
+			exported_object: request.exported_object,
+			parameters: request.parameters,
+			result: null,
+			user_id: null,
+		})
+	})
+})

--- a/packages/sdk/test/exports.spec.ts
+++ b/packages/sdk/test/exports.spec.ts
@@ -47,7 +47,7 @@ describe('Exports API', () => {
 		if (!justExported.parameters.filters) {
 			return
 		}
-		expect(justExported as ExportResourceResponse).toMatchObject({
+		expect(justExported).toMatchObject({
 			id: expect.stringMatching(/^exp-*/),
 			object: 'export',
 			created_at: expect.stringMatching(isoRegex),

--- a/packages/sdk/test/exports.spec.ts
+++ b/packages/sdk/test/exports.spec.ts
@@ -1,6 +1,5 @@
 import { voucherifyClient as client } from './client'
 import { isoRegex } from './utils/isoRegex'
-import { ExportResourceResponse } from '@voucherify/sdk'
 
 describe('Exports API', () => {
 	it('Should create export, with no parameters', async () => {


### PR DESCRIPTION
---
'@voucherify/sdk': minor
---

Add support for endpoint `GET /exports`.
- New exported types/interfaces: `ExportsListRequestQuery`, `ExportsListResponseBody`, `ExportBase`, `ExportResourceResponse`, `FieldConditions`, `ExportVoucher`, `ExportVoucherFilters`, `ExportRedemption`, `ExportRedemptionFilters`, `ExportCustomer`, `ExportCustomerFilters`, `ExportPublication`, `ExportPublicationFilters`, `ExportOrder`, `ExportOrderFilters`, `ExportPointsExpiration`, `ExportPointsExpirationFilters`, `ExportVoucherTransactionsExpiration`, `ExportVoucherTransactionsFilters`, `Junction`, `FiltersCondition`, `ExportCustomerFields`, `ExportCustomerOrder`, `ExportPublicationFields`, `ExportPublicationOrder`, `ExportRedemptionFields`, `ExportRedemptionOrder`, `ExportVoucherFields`, `ExportVoucherOrder`, `ExportOrderFields`, `ExportOrderOrder`, `ExportPointsExpirationFields`, `ExportPointsExpirationOrder`, `ExportVoucherTransactionsFields`, `ExportVoucherTransactionsOrder`
