### PR TITLE
Fx for list categories

### DIFF
--- a/.changeset/pis-ko-po.md
+++ b/.changeset/pis-ko-po.md
@@ -1,0 +1,8 @@
+---
+'@voucherify/sdk': minor
+---
+
+New exported types/interfaces in `Categories.ts`:
+- CategoriesListRequestQuery
+
+Added support for query parameters(CategoriesListRequestQuery) in `/categories` (categories.list method)

--- a/packages/sdk/src/Categories.ts
+++ b/packages/sdk/src/Categories.ts
@@ -8,8 +8,8 @@ export class Categories {
 	/**
 	 * @see https://docs.voucherify.io/reference/list-categories
 	 */
-	public list() {
-		return this.client.get<T.ListCategories>('/categories')
+	public list(params: T.CategoriesListRequestQuery = {}) {
+		return this.client.get<T.ListCategories>('/categories', params)
 	}
 	/**
 	 * @see https://docs.voucherify.io/reference/create-category

--- a/packages/sdk/src/types/Categories.ts
+++ b/packages/sdk/src/types/Categories.ts
@@ -3,6 +3,7 @@ export interface ListCategories {
 	data_ref: 'data'
 	data: CategoryObject[]
 	total: number
+	has_more: boolean
 }
 
 export type CategoryObject = ResponseCreateCategory & {
@@ -37,4 +38,11 @@ export type Category = {
 	created_at: string
 	updated_at?: string
 	object: 'category'
+}
+
+// 0-level types
+
+export type CategoriesListRequestQuery = {
+	limit?: number
+	starting_after_id?: number
 }

--- a/packages/sdk/test/categories.spec.ts
+++ b/packages/sdk/test/categories.spec.ts
@@ -40,14 +40,14 @@ describe('Categories API', () => {
 	})
 
 	it('should list categories', async () => {
-		const categoriesList = await client.categories.list()
+		const categoriesList = await client.categories.list({ limit: 100 })
 		expect(categoriesList).toMatchObject(
 			expect.objectContaining({
 				object: 'list',
 				data_ref: 'data',
-				has_more: false,
 			}),
 		)
+		expect(typeof categoriesList.has_more).toBe('boolean')
 		expect(typeof categoriesList.total).toBe('number')
 		expect(Array.isArray(categoriesList.data)).toBeTruthy()
 		categoriesList.data.forEach(category => {


### PR DESCRIPTION
---
'@voucherify/sdk': minor
---

New exported types/interfaces in `Categories.ts`:
- CategoriesListRequestQuery

Added support for query parameters(CategoriesListRequestQuery) in `/categories` (categories.list method)
