### PR TITLE
use event persistence to support older versions of react

### DIFF
--- a/packages/react-widget/src/hooks/useVoucherifyValidateInputs.ts
+++ b/packages/react-widget/src/hooks/useVoucherifyValidateInputs.ts
@@ -26,6 +26,7 @@ export function useVoucherifyValidateInputs() {
 	const [inputState, setInputState] = useState(getEmptyInputState)
 
 	const onInputChange = useCallback(function onChange(event: React.ChangeEvent<HTMLInputElement>) {
+		event.persist()
 		const name = event.target.name as keyof VoucherifyValidateInputs
 		setInput(prev => ({ ...prev, [name]: event.target.value }))
 	}, [])


### PR DESCRIPTION
In React <17, event pooling can cause the input event to be reused, throwing the following error on input change when attempting to access the event target value:

`Cannot read properties of null (reading 'value')`

This PR adds `event.persist()` which resolves the error in React <17, and is a no-op in React >= 17.