### PR TITLE
v2.9.1 - Added missing type properties in voucher.loyalty_card

### DIFF
--- a/.changeset/seven-tools-drum.md
+++ b/.changeset/seven-tools-drum.md
@@ -1,0 +1,5 @@
+---
+'@voucherify/sdk': patch
+---
+
+Added missing type properties in voucher.loyalty_card - for example for requesting voucher/loyalty member

--- a/packages/sdk/src/types/Loyalties.ts
+++ b/packages/sdk/src/types/Loyalties.ts
@@ -269,6 +269,8 @@ export interface LoyaltiesVoucherResponse {
 	loyalty_card: {
 		points: number
 		balance: number
+		next_expiration_date?: string
+		next_expiration_points?: number
 	}
 	start_date?: string
 	expiration_date?: string

--- a/packages/sdk/src/types/Vouchers.ts
+++ b/packages/sdk/src/types/Vouchers.ts
@@ -38,6 +38,9 @@ export interface VouchersResponse {
 	}
 	loyalty_card?: {
 		points: number
+		balance: number
+		next_expiration_date?: string
+		next_expiration_points?: number
 	}
 	start_date?: string
 	expiration_date?: string


### PR DESCRIPTION
Added missing type properties in voucher.loyalty_card - for example for requesting voucher/loyalty member

Requested by a customer